### PR TITLE
Don't issue a new capability on every sale transaction

### DIFF
--- a/transactions-v1/sell_item.cdc
+++ b/transactions-v1/sell_item.cdc
@@ -20,10 +20,23 @@ transaction(saleItemID: UInt64, saleItemPrice: UFix64) {
         self.exampleTokenReceiver = acct.capabilities.get<&{FungibleToken.Receiver}>(/public/exampleTokenReceiver)
         assert(self.exampleTokenReceiver.check(), message: "Missing or mis-typed ExampleToken Receiver")
 
-        self.exampleNFTProvider = acct.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}>(
+        // The storage path for storing a withdraw capability to the nft collection
+        // Should preferrably be defined in the nft contract
+        let nftProviderCapPath = /storage/ExampleNFTProviderCap
+        var nftProviderCap = acct.storage.copy<Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}>>(from: nftProviderCapPath)
+        if nftProviderCap == nil || !nftProviderCap!.check() {
+            self.exampleNFTProvider = acct.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}>(
                 collectionData.storagePath
             )
-        assert(self.exampleNFTProvider.check(), message: "Missing or mis-typed ExampleNFT provider")
+            assert(self.exampleNFTProvider.check(), message: "Missing or mis-typed ExampleNFT provider")
+             // save capability to storage
+            acct.storage.save(
+                self.exampleNFTProvider,
+                to: nftProviderCapPath
+            )
+        } else{
+            self.exampleNFTProvider = nftProviderCap!
+        }
 
         // If the account doesn't already have a Storefront
         if acct.storage.borrow<&NFTStorefront.Storefront>(from: NFTStorefront.StorefrontStoragePath) == nil {

--- a/transactions/sell_item.cdc
+++ b/transactions/sell_item.cdc
@@ -43,10 +43,23 @@ transaction(
         self.tokenReceiver = acct.capabilities.get<&{FungibleToken.Receiver}>(/public/exampleTokenReceiver)
         assert(self.tokenReceiver.borrow() != nil, message: "Missing or mis-typed ExampleToken receiver")
 
-        self.exampleNFTProvider = acct.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}>(
+        // The storage path for storing a withdraw capability to the nft collection
+        // Should preferrably be defined in the nft contract
+        let nftProviderCapPath = /storage/ExampleNFTProviderCap
+        var nftProviderCap = acct.storage.copy<Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}>>(from: nftProviderCapPath)
+        if nftProviderCap == nil || !nftProviderCap!.check() {
+            self.exampleNFTProvider = acct.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}>(
                 collectionData.storagePath
             )
-        assert(self.exampleNFTProvider.check(), message: "Missing or mis-typed ExampleNFT provider")
+            assert(self.exampleNFTProvider.check(), message: "Missing or mis-typed ExampleNFT provider")
+             // save capability to storage
+            acct.storage.save(
+                self.exampleNFTProvider,
+                to: nftProviderCapPath
+            )
+        } else{
+            self.exampleNFTProvider = nftProviderCap!
+        }
 
         let collection = acct.capabilities.borrow<&{NonFungibleToken.Collection}>(
                 collectionData.publicPath

--- a/transactions/sell_item_and_replace_current_listing.cdc
+++ b/transactions/sell_item_and_replace_current_listing.cdc
@@ -43,10 +43,23 @@ transaction(
         self.tokenReceiver = acct.capabilities.get<&{FungibleToken.Receiver}>(/public/exampleTokenReceiver)
         assert(self.tokenReceiver.borrow() != nil, message: "Missing or mis-typed ExampleToken receiver")
 
-        self.exampleNFTProvider = acct.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}>(
+        // The storage path for storing a withdraw capability to the nft collection
+        // Should preferrably be defined in the nft contract
+        let nftProviderCapPath = /storage/ExampleNFTProviderCap
+        var nftProviderCap = acct.storage.copy<Capability<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}>>(from: nftProviderCapPath)
+        if nftProviderCap == nil || !nftProviderCap!.check() {
+            self.exampleNFTProvider = acct.capabilities.storage.issue<auth(NonFungibleToken.Withdraw) &{NonFungibleToken.Collection}>(
                 collectionData.storagePath
             )
-        assert(self.exampleNFTProvider.check(), message: "Missing or mis-typed ExampleNFT provider")
+            assert(self.exampleNFTProvider.check(), message: "Missing or mis-typed ExampleNFT provider")
+             // save capability to storage
+            acct.storage.save(
+                self.exampleNFTProvider,
+                to: nftProviderCapPath
+            )
+        } else{
+            self.exampleNFTProvider = nftProviderCap!
+        }
 
         let collection = acct.capabilities.borrow<&{NonFungibleToken.Collection}>(
                 collectionData.publicPath


### PR DESCRIPTION
This adds a check for an existing capability. if none is found, it creates a new one and saves it in storage to be reused 